### PR TITLE
Fix fatal error in getTodaysRecords()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/vendor/
+composer.lock
+.phpunit.result.cache
+/coverage/

--- a/src/Lib/ZKTeco.php
+++ b/src/Lib/ZKTeco.php
@@ -430,10 +430,10 @@ class ZKTeco
         return Attendance::get($this, $limit);
     }
 
-    public static function getTodaysRecords(ZKTeco $self)
+    public function getTodaysRecords()
     {
         // Get all attendance records from the device
-        $attendanceData = self::get($self);
+        $attendanceData = $this->getAttendance();
 
         // Get today's date
         $currentDate = date('Y-m-d');

--- a/tests/AttendanceTodaysRecordsTest.php
+++ b/tests/AttendanceTodaysRecordsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use Jmrashed\Zkteco\Lib\ZKTeco;
+
+class AttendanceTodaysRecordsTest extends TestCase
+{
+    public function testGetTodaysRecordsCanBeCalledAsInstanceMethod()
+    {
+        $today = date('Y-m-d');
+
+        $zk = $this->getMockBuilder(ZKTeco::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getAttendance'])
+            ->getMock();
+
+        $zk->method('getAttendance')->willReturn([
+            ['uid' => 1, 'id' => 'A1', 'state' => 1, 'timestamp' => $today . ' 08:00:00', 'type' => 0],
+            ['uid' => 2, 'id' => 'A2', 'state' => 1, 'timestamp' => '2000-01-01 08:00:00', 'type' => 0],
+        ]);
+
+        // Previously getTodaysRecords() was declared `static function getTodaysRecords(ZKTeco $self)`
+        // which made calling it as `$zk->getTodaysRecords()` (per the documented usage) fatal
+        // with "Too few arguments" / undefined method self::get(). This must not throw.
+        $result = $zk->getTodaysRecords();
+
+        $this->assertCount(1, $result);
+        $this->assertEquals(1, reset($result)['uid']);
+    }
+}


### PR DESCRIPTION
## Summary
- `getTodaysRecords()` was declared `static function getTodaysRecords(ZKTeco $self)` and internally called `self::get($self)`, a method that does not exist on `ZKTeco`.
- The README documents (and issue #3 reproduces) calling it as `$zk->getTodaysRecords()` — an instance call with no arguments — which is a fatal error against the static signature.
- Converted it to a normal instance method that delegates to `$this->getAttendance()`, matching every other method on the class and the documented usage.

## Test plan
- [x] Added `tests/AttendanceTodaysRecordsTest.php` covering the instance-call path and date filtering.
- [x] `vendor/bin/phpunit` passes for the new test.
- [x] Confirmed pre-existing unrelated test failures (some `EnhancedUserManagementTest`/`AdvancedDeviceManagementTest` cases return `null` from bare mocks) are present on `main` too and unaffected by this change.

Fixes #3