### PR TITLE
Fix fingerprint template upload for payloads larger than one packet

### DIFF
--- a/src/Lib/Helper/Fingerprint.php
+++ b/src/Lib/Helper/Fingerprint.php
@@ -131,10 +131,10 @@ class Fingerprint
      */
     private function _setFinger(ZKTeco $self, $data)
     {
-        $command = Util::CMD_USER_TEMP_WRQ;
-        $command_string = $data;
-
-        return $self->_command($command, $command_string);
+        // Fingerprint templates (commonly 500-1500+ bytes) exceed a single
+        // UDP packet, so use the chunked buffer protocol instead of sending
+        // the whole template in one CMD_USER_TEMP_WRQ packet.
+        return Util::sendWithBuffer($self, Util::CMD_USER_TEMP_WRQ, $data);
     }
 
     /**

--- a/src/Lib/Helper/Util.php
+++ b/src/Lib/Helper/Util.php
@@ -37,6 +37,8 @@ class Util
   const CMD_DATA = 1501; # Transmit a data packet
   const CMD_FREE_DATA = 1502; # Clear machines open buffer
 
+  const MAX_CHUNK_SIZE = 1024; # Max bytes per CMD_DATA packet when buffering a large upload
+
   const CMD_USER_TEMP_RRQ = 9; # Read some fingerprint template or some kind of data entirely
   const CMD_ATT_LOG_RRQ = 13; # Read all attendance record
   const CMD_CLEAR_DATA = 14; # Clear Data
@@ -407,6 +409,39 @@ class Util
     }
 
     return $data;
+  }
+
+  /**
+   * Send a payload to the device, transparently using the chunked
+   * CMD_PREPARE_DATA/CMD_DATA buffer protocol when the payload is too
+   * large to fit in a single packet (e.g. fingerprint templates, which
+   * are commonly 500-1500+ bytes). Small payloads are sent directly with
+   * $command, unchanged from the previous behavior.
+   *
+   * @param ZKTeco $self
+   * @param int $command Final command to issue once the buffer is uploaded (e.g. CMD_USER_TEMP_WRQ)
+   * @param string $data Raw payload to send
+   * @return bool|mixed Result of the final command, or false if any step fails
+   */
+  static public function sendWithBuffer(ZKTeco $self, $command, $data)
+  {
+    if (strlen($data) <= self::MAX_CHUNK_SIZE) {
+      return $self->_command($command, $data);
+    }
+
+    $prepared = $self->_command(self::CMD_PREPARE_DATA, pack('V', strlen($data)));
+    if ($prepared === false) {
+      return false;
+    }
+
+    foreach (str_split($data, self::MAX_CHUNK_SIZE) as $chunk) {
+      $sent = $self->_command(self::CMD_DATA, $chunk);
+      if ($sent === false) {
+        return false;
+      }
+    }
+
+    return $self->_command($command, '');
   }
 
   /**

--- a/tests/SendWithBufferTest.php
+++ b/tests/SendWithBufferTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use Jmrashed\Zkteco\Lib\ZKTeco;
+use Jmrashed\Zkteco\Lib\Helper\Util;
+
+class SendWithBufferTest extends TestCase
+{
+    public function testSmallPayloadIsSentDirectly()
+    {
+        $zk = $this->getMockBuilder(ZKTeco::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['_command'])
+            ->getMock();
+
+        $zk->expects($this->once())
+            ->method('_command')
+            ->with(999, 'small-payload')
+            ->willReturn(true);
+
+        $result = Util::sendWithBuffer($zk, 999, 'small-payload');
+
+        $this->assertTrue($result);
+    }
+
+    public function testLargePayloadIsChunkedThroughPrepareDataAndData()
+    {
+        $data = str_repeat('A', Util::MAX_CHUNK_SIZE) . str_repeat('B', 200);
+        $calls = [];
+
+        $zk = $this->getMockBuilder(ZKTeco::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['_command'])
+            ->getMock();
+
+        $zk->method('_command')->willReturnCallback(function ($command, $string) use (&$calls) {
+            $calls[] = [$command, $string];
+            return true;
+        });
+
+        $result = Util::sendWithBuffer($zk, 999, $data);
+
+        $this->assertTrue($result);
+        $this->assertCount(4, $calls);
+
+        // 1. CMD_PREPARE_DATA with the total size packed as a 4-byte uint
+        $this->assertEquals(Util::CMD_PREPARE_DATA, $calls[0][0]);
+        $this->assertEquals(pack('V', strlen($data)), $calls[0][1]);
+
+        // 2-3. CMD_DATA chunks, each no larger than MAX_CHUNK_SIZE, concatenating back to the original data
+        $this->assertEquals(Util::CMD_DATA, $calls[1][0]);
+        $this->assertEquals(Util::MAX_CHUNK_SIZE, strlen($calls[1][1]));
+        $this->assertEquals(Util::CMD_DATA, $calls[2][0]);
+        $this->assertEquals(200, strlen($calls[2][1]));
+        $this->assertEquals($data, $calls[1][1] . $calls[2][1]);
+
+        // 4. The real command is finally issued with an empty string, since the data is already buffered
+        $this->assertEquals(999, $calls[3][0]);
+        $this->assertEquals('', $calls[3][1]);
+    }
+
+    public function testReturnsFalseIfAnyStepFails()
+    {
+        $data = str_repeat('A', Util::MAX_CHUNK_SIZE + 1);
+
+        $zk = $this->getMockBuilder(ZKTeco::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['_command'])
+            ->getMock();
+
+        $zk->method('_command')->willReturn(false);
+
+        $result = Util::sendWithBuffer($zk, 999, $data);
+
+        $this->assertFalse($result);
+    }
+}


### PR DESCRIPTION
## Summary
- `Fingerprint::_setFinger()` sent the entire fingerprint template (6-byte header + template data, commonly 500-1500+ bytes) as a single `CMD_USER_TEMP_WRQ` packet.
- The device protocol already defines `CMD_PREPARE_DATA` / `CMD_DATA` (see `Util.php`) specifically for payloads too large for one packet, but nothing in the codebase used them for uploads.
- This is why `setFingerprint()` / `enrollFingerprint()` fail against real templates (issue #6, #11) while unit tests pass — the test fixtures are a few bytes, real templates aren't.
- Added `Util::sendWithBuffer()`: sends small payloads directly (unchanged behavior), and for larger payloads announces the size via `CMD_PREPARE_DATA`, uploads it in `CMD_DATA` chunks of `Util::MAX_CHUNK_SIZE` (1024) bytes, then issues the target command with an empty body since the data is already buffered. Wired `Fingerprint::_setFinger` through it.

## Test plan
- [x] `tests/SendWithBufferTest.php`: verifies small payloads bypass chunking, large payloads are split into the right `CMD_PREPARE_DATA`/`CMD_DATA` sequence with correct byte boundaries, and any failed step returns false.
- [x] Full suite run — no new failures beyond the pre-existing unrelated mock-based test failures already on `main`.
- [ ] Real-device validation is recommended before relying on this for production enrollment — I don't have physical ZKTeco hardware to test against, so this fixes the identified transport-layer gap based on the protocol constants already present in this codebase, but hasn't been confirmed against a live device.

Fixes #11
Fixes #6