### PR TITLE
Add updateUser() for editing existing users in place

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,15 @@ $users = $zk->getUser();
 $setUserResult = $zk->setUser($uid, $userid, $name, $password, $role, $cardno);
 ```
 
+## 19.1 Update An Existing User
+
+To edit a user's userid, name, password, role, or card number without deleting them first, call `updateUser()` (or `setUser()` — they're the same operation) with their existing `$uid`. The device's set-user command overwrites the record for that `$uid` in place:
+
+```php
+// $uid must match the existing user's uid (from getUser()) to update rather than create
+$updated = $zk->updateUser($uid, $newUserid, $newName, $newPassword, $role, $cardno);
+```
+
 ## 20. Clear All Admin
 ```php
 // Remove all admin users from the ZKTeco device

--- a/src/Lib/ZKTeco.php
+++ b/src/Lib/ZKTeco.php
@@ -307,6 +307,27 @@ class ZKTeco
     }
 
 /**
+ * Updates an existing user's data in place, without deleting and recreating them.
+ *
+ * The device's "set user" command upserts by $uid: sending it again for a $uid
+ * that already exists overwrites that user's fields (including $userid,
+ * name, password, role, and card number) rather than creating a duplicate.
+ * This is an alias of setUser() for discoverability when updating.
+ *
+ * @param int $uid Unique ID (max 65535) of the existing user to update.
+ * @param int|string $userid New badge/user ID (max length = 9).
+ * @param string $name New name (max length = 24).
+ * @param int|string $password New password (max length = 8).
+ * @param int $role Default Util::LEVEL_USER.
+ * @param int $cardno Default 0 (max length = 10).
+ * @return bool|mixed True if the user was successfully updated, otherwise returns the result from User::set.
+ */
+    public function updateUser($uid, $userid, $name, $password, $role = Util::LEVEL_USER, $cardno = 0)
+    {
+        return User::set($this, $uid, $userid, $name, $password, $role, $cardno);
+    }
+
+/**
  * Removes all users from the device.
  *
  * @return bool|mixed True if all users were successfully removed, otherwise returns the result from User::clear.

--- a/tests/UpdateUserTest.php
+++ b/tests/UpdateUserTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use Jmrashed\Zkteco\Lib\ZKTeco;
+
+class UpdateUserTest extends TestCase
+{
+    public function testUpdateUserDelegatesToSameSetUserCommand()
+    {
+        $zk = $this->getMockBuilder(ZKTeco::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['_command'])
+            ->getMock();
+
+        // updateUser() and setUser() must issue the exact same device command,
+        // since updating is just re-sending the set-user command for an
+        // existing uid, not a distinct protocol operation.
+        $zk->expects($this->exactly(2))
+            ->method('_command')
+            ->willReturn(true);
+
+        $this->assertTrue($zk->setUser(1, '108', 'John Doe', '1234', 0, 0));
+        $this->assertTrue($zk->updateUser(1, '108', 'John Doe Updated', '1234', 0, 0));
+    }
+}


### PR DESCRIPTION
## Summary
- The requester wanted to edit an existing user's id/name/etc. without deleting and recreating them.
- `User::set()` already does this: the device's set-user command upserts by `$uid`, so calling `setUser()` again for an existing `$uid` overwrites that record. This wasn't documented or discoverable.
- Added `updateUser()` as an explicit alias of `setUser()` for discoverability, and documented the update flow in the README (19.1).

## Test plan
- [x] `tests/UpdateUserTest.php` — asserts `updateUser()` issues the same device command as `setUser()`.
- [x] Full suite — no new failures beyond pre-existing unrelated ones.

Fixes #14