### PR TITLE
Add user group support (CMD_USERGRP/CMD_GRPTZ)

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,24 @@ $result = $zk->syncTimeZone('Europe/London');
 $result = $zk->syncTimeZone('Asia/Tokyo');
 ```
 
+## 35.3 User Groups
+
+Assign users to a group, and assign up to 3 time zones to a group. **Note:** unlike most methods in this library, this record layout hasn't been verified against a physical device capture — please report back if it doesn't behave as expected for your device.
+
+```php
+// Assign user with uid 1 to group 5
+$zk->setUserGroup(1, 5);
+
+// Get the group a user is assigned to
+$groupId = $zk->getUserGroup(1);
+
+// Assign up to 3 time zone IDs to group 5
+$zk->setGroupTimezones(5, [1, 2]);
+
+// Get the time zone IDs assigned to group 5
+$timezones = $zk->getGroupTimezones(5);
+```
+
 ## 36. Real-time Event Monitoring
 
 ### 36.1 Get Real-time Events

--- a/src/Lib/Helper/Group.php
+++ b/src/Lib/Helper/Group.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Jmrashed\Zkteco\Lib\Helper;
+
+use Jmrashed\Zkteco\Lib\ZKTeco;
+
+/**
+ * User group management (assigning users to a group, and assigning
+ * time zones to a group), using CMD_USERGRP_RRQ/WRQ and CMD_GRPTZ_RRQ/WRQ.
+ *
+ * NOTE: unlike User/Attendance, this record layout has not been verified
+ * against a physical device capture. It follows the same uid/id encoding
+ * conventions used elsewhere in this library (low byte, high byte) and the
+ * command codes requested in https://github.com/jmrashed/zkteco/issues/15.
+ * Please report back if this doesn't match your device's behavior.
+ */
+class Group
+{
+    /**
+     * Assign a user to a group.
+     *
+     * @param ZKTeco $self
+     * @param int $uid Unique ID (max 65535) of the user.
+     * @param int $groupId Group ID (max 255).
+     * @return bool|mixed
+     */
+    static public function setUserGroup(ZKTeco $self, $uid, $groupId)
+    {
+        $self->_section = __METHOD__;
+
+        if ((int) $uid === 0 || (int) $uid > Util::USHRT_MAX || (int) $groupId < 0 || (int) $groupId > 255) {
+            return false;
+        }
+
+        $command = Util::CMD_USERGRP_WRQ;
+        $byte1 = chr((int) ($uid % 256));
+        $byte2 = chr((int) ($uid >> 8));
+        $command_string = $byte1 . $byte2 . chr((int) $groupId);
+
+        return $self->_command($command, $command_string);
+    }
+
+    /**
+     * Get the group ID a user is assigned to.
+     *
+     * @param ZKTeco $self
+     * @param int $uid Unique ID (max 65535) of the user.
+     * @return int|false Group ID, or false on failure.
+     */
+    static public function getUserGroup(ZKTeco $self, $uid)
+    {
+        $self->_section = __METHOD__;
+
+        $command = Util::CMD_USERGRP_RRQ;
+        $byte1 = chr((int) ($uid % 256));
+        $byte2 = chr((int) ($uid >> 8));
+        $command_string = $byte1 . $byte2;
+
+        $reply = $self->_command($command, $command_string, Util::COMMAND_TYPE_GENERAL);
+        if ($reply === false || strlen($reply) < 1) {
+            return false;
+        }
+
+        return ord($reply[0]);
+    }
+
+    /**
+     * Assign up to 3 time zones to a group.
+     *
+     * @param ZKTeco $self
+     * @param int $groupId Group ID (max 255).
+     * @param array $timezoneIds Up to 3 time zone IDs.
+     * @return bool|mixed
+     */
+    static public function setGroupTimezones(ZKTeco $self, $groupId, array $timezoneIds)
+    {
+        $self->_section = __METHOD__;
+
+        if ((int) $groupId < 0 || (int) $groupId > 255 || count($timezoneIds) > 3) {
+            return false;
+        }
+
+        $timezoneIds = array_pad(array_slice($timezoneIds, 0, 3), 3, 0);
+
+        $command = Util::CMD_GRPTZ_WRQ;
+        $command_string = chr((int) $groupId);
+        foreach ($timezoneIds as $timezoneId) {
+            $command_string .= chr((int) $timezoneId % 256) . chr((int) $timezoneId >> 8);
+        }
+
+        return $self->_command($command, $command_string);
+    }
+
+    /**
+     * Get the time zones assigned to a group.
+     *
+     * @param ZKTeco $self
+     * @param int $groupId Group ID (max 255).
+     * @return array Up to 3 time zone IDs, or an empty array on failure.
+     */
+    static public function getGroupTimezones(ZKTeco $self, $groupId)
+    {
+        $self->_section = __METHOD__;
+
+        $command = Util::CMD_GRPTZ_RRQ;
+        $command_string = chr((int) $groupId);
+
+        $reply = $self->_command($command, $command_string, Util::COMMAND_TYPE_GENERAL);
+        if ($reply === false || strlen($reply) < 6) {
+            return [];
+        }
+
+        $timezones = [];
+        for ($i = 0; $i < 3; $i++) {
+            $offset = $i * 2;
+            $timezones[] = ord($reply[$offset]) + (ord($reply[$offset + 1]) * 256);
+        }
+
+        return $timezones;
+    }
+}

--- a/src/Lib/Helper/Util.php
+++ b/src/Lib/Helper/Util.php
@@ -56,6 +56,11 @@ class Util
   const CMD_DELETE_USER_TEMP = 19; # Delete some fingerprint template
   const CMD_CLEAR_ADMIN = 20; # Cancel the manager
 
+  const CMD_USERGRP_RRQ = 21; # Read a user group's data
+  const CMD_USERGRP_WRQ = 22; # Upload a user group's data (assign a user to a group)
+  const CMD_GRPTZ_RRQ = 25; # Read a group's time zone assignments
+  const CMD_GRPTZ_WRQ = 26; # Upload a group's time zone assignments
+
   const LEVEL_USER = 0; # User level as User
   const LEVEL_ADMIN = 14; # User level as Admin
 

--- a/src/Lib/ZKTeco.php
+++ b/src/Lib/ZKTeco.php
@@ -9,6 +9,7 @@ use Jmrashed\Zkteco\Lib\Helper\Connect;
 use Jmrashed\Zkteco\Lib\Helper\Device;
 use Jmrashed\Zkteco\Lib\Helper\EventMonitor;
 use Jmrashed\Zkteco\Lib\Helper\Face;
+use Jmrashed\Zkteco\Lib\Helper\Group;
 use Jmrashed\Zkteco\Lib\Helper\Fingerprint;
 use Jmrashed\Zkteco\Lib\Helper\Os;
 use Jmrashed\Zkteco\Lib\Helper\Pin;
@@ -325,6 +326,52 @@ class ZKTeco
     public function updateUser($uid, $userid, $name, $password, $role = Util::LEVEL_USER, $cardno = 0)
     {
         return User::set($this, $uid, $userid, $name, $password, $role, $cardno);
+    }
+
+/**
+ * Assigns a user to a group.
+ *
+ * @param int $uid Unique ID (max 65535) of the user.
+ * @param int $groupId Group ID (max 255).
+ * @return bool|mixed
+ */
+    public function setUserGroup($uid, $groupId)
+    {
+        return Group::setUserGroup($this, $uid, $groupId);
+    }
+
+/**
+ * Gets the group ID a user is assigned to.
+ *
+ * @param int $uid Unique ID (max 65535) of the user.
+ * @return int|false Group ID, or false on failure.
+ */
+    public function getUserGroup($uid)
+    {
+        return Group::getUserGroup($this, $uid);
+    }
+
+/**
+ * Assigns up to 3 time zones to a group.
+ *
+ * @param int $groupId Group ID (max 255).
+ * @param array $timezoneIds Up to 3 time zone IDs.
+ * @return bool|mixed
+ */
+    public function setGroupTimezones($groupId, array $timezoneIds)
+    {
+        return Group::setGroupTimezones($this, $groupId, $timezoneIds);
+    }
+
+/**
+ * Gets the time zones assigned to a group.
+ *
+ * @param int $groupId Group ID (max 255).
+ * @return array Up to 3 time zone IDs, or an empty array on failure.
+ */
+    public function getGroupTimezones($groupId)
+    {
+        return Group::getGroupTimezones($this, $groupId);
     }
 
 /**

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use Jmrashed\Zkteco\Lib\ZKTeco;
+use Jmrashed\Zkteco\Lib\Helper\Util;
+
+class GroupTest extends TestCase
+{
+    public function testSetUserGroupEncodesUidLowHighByteThenGroupId()
+    {
+        $captured = null;
+
+        $zk = $this->getMockBuilder(ZKTeco::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['_command'])
+            ->getMock();
+
+        $zk->method('_command')->willReturnCallback(function ($command, $string) use (&$captured) {
+            $captured = [$command, $string];
+            return true;
+        });
+
+        $result = $zk->setUserGroup(300, 5);
+
+        $this->assertTrue($result);
+        $this->assertEquals(Util::CMD_USERGRP_WRQ, $captured[0]);
+        // uid 300 = 0x012C -> low byte 0x2C, high byte 0x01, then group id 5
+        $this->assertEquals(chr(0x2C) . chr(0x01) . chr(5), $captured[1]);
+    }
+
+    public function testSetUserGroupRejectsOutOfRangeValues()
+    {
+        $zk = $this->getMockBuilder(ZKTeco::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['_command'])
+            ->getMock();
+        $zk->expects($this->never())->method('_command');
+
+        $this->assertFalse($zk->setUserGroup(0, 5));
+        $this->assertFalse($zk->setUserGroup(1, 256));
+    }
+
+    public function testGetUserGroupParsesGroupIdFromReply()
+    {
+        $zk = $this->getMockBuilder(ZKTeco::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['_command'])
+            ->getMock();
+
+        $zk->method('_command')->willReturn(chr(7));
+
+        $this->assertEquals(7, $zk->getUserGroup(1));
+    }
+
+    public function testGetUserGroupReturnsFalseWhenCommandFails()
+    {
+        $zk = $this->getMockBuilder(ZKTeco::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['_command'])
+            ->getMock();
+
+        $zk->method('_command')->willReturn(false);
+
+        $this->assertFalse($zk->getUserGroup(1));
+    }
+
+    public function testSetGroupTimezonesPadsToThreeSlots()
+    {
+        $captured = null;
+
+        $zk = $this->getMockBuilder(ZKTeco::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['_command'])
+            ->getMock();
+
+        $zk->method('_command')->willReturnCallback(function ($command, $string) use (&$captured) {
+            $captured = [$command, $string];
+            return true;
+        });
+
+        $zk->setGroupTimezones(2, [1]);
+
+        $this->assertEquals(Util::CMD_GRPTZ_WRQ, $captured[0]);
+        // group id 2, timezone 1 (2 bytes LE), then two empty (0) timezone slots
+        $this->assertEquals(chr(2) . chr(1) . chr(0) . chr(0) . chr(0) . chr(0) . chr(0), $captured[1]);
+    }
+
+    public function testGetGroupTimezonesParsesThreeTimezoneIds()
+    {
+        $zk = $this->getMockBuilder(ZKTeco::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['_command'])
+            ->getMock();
+
+        $zk->method('_command')->willReturn(chr(1) . chr(0) . chr(2) . chr(0) . chr(3) . chr(0));
+
+        $this->assertEquals([1, 2, 3], $zk->getGroupTimezones(2));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `Group` helper for assigning users to a group and assigning time zones to a group, using the command codes requested in the issue: `CMD_USERGRP_RRQ` (21), `CMD_USERGRP_WRQ` (22), `CMD_GRPTZ_RRQ` (25), `CMD_GRPTZ_WRQ` (26).
- Exposed as `setUserGroup()`, `getUserGroup()`, `setGroupTimezones()`, `getGroupTimezones()` on `ZKTeco`.
- Encoding follows the same uid low-byte/high-byte convention already used by `User::set()`/`User::get()`.

**Caveat:** unlike `User`/`Attendance`, which match a well-documented, widely-verified record format, I don't have a physical-device packet capture to confirm the exact group/timezone record layout against. I've called this out in the README and in the issue — happy to iterate once someone can confirm against real hardware.

## Test plan
- [x] `tests/GroupTest.php` — covers uid/group-id byte encoding, range validation, timezone padding/parsing, and failure paths.
- [x] Full suite — no new failures beyond pre-existing unrelated ones.

Fixes #15