### PR TITLE
Guard against short/empty socket data instead of unpack() warnings

### DIFF
--- a/src/Lib/Helper/Connect.php
+++ b/src/Lib/Helper/Connect.php
@@ -86,8 +86,11 @@ class Connect
         $session_id = $self->_session_id;
 
         // Unpack the data received during connection to extract reply ID.
-        $u = unpack('H2h1/H2h2/H2h3/H2h4/H2h5/H2h6/H2h7/H2h8', substr($self->_data_recv, 0, 8));
-        $reply_id = hexdec($u['h8'] . $u['h7']);
+        $reply_id = 0;
+        if (strlen($self->_data_recv) >= 8) {
+            $u = unpack('H2h1/H2h2/H2h3/H2h4/H2h5/H2h6/H2h7/H2h8', substr($self->_data_recv, 0, 8));
+            $reply_id = hexdec($u['h8'] . $u['h7']);
+        }
 
         // Create the header for the command.
         $buf = Util::createHeader($command, $chksum, $session_id, $reply_id, $command_string);

--- a/src/Lib/Helper/Util.php
+++ b/src/Lib/Helper/Util.php
@@ -182,10 +182,14 @@ class Util
    */
   static public function getSize(ZKTeco $self)
   {
+    if (strlen($self->_data_recv) < 8) {
+      return false;
+    }
+
     $u = unpack('H2h1/H2h2/H2h3/H2h4/H2h5/H2h6/H2h7/H2h8', substr($self->_data_recv, 0, 8));
     $command = hexdec($u['h2'] . $u['h1']);
 
-    if ($command == self::CMD_PREPARE_DATA) {
+    if ($command == self::CMD_PREPARE_DATA && strlen($self->_data_recv) >= 12) {
       $u = unpack('H2h1/H2h2/H2h3/H2h4', substr($self->_data_recv, 8, 4));
       $size = hexdec($u['h4'] . $u['h3'] . $u['h2'] . $u['h1']);
       return $size;
@@ -280,6 +284,10 @@ class Util
    */
   static public function checkValid($reply)
   {
+    if (strlen($reply) < 8) {
+      return false;
+    }
+
     $u = unpack('H2h1/H2h2', substr($reply, 0, 8));
 
     $command = hexdec($u['h2'] . $u['h1']);

--- a/src/Lib/ZKTeco.php
+++ b/src/Lib/ZKTeco.php
@@ -74,8 +74,14 @@ class ZKTeco
         $chksum = 0;
         $session_id = $this->_session_id;
 
-        $u = unpack('H2h1/H2h2/H2h3/H2h4/H2h5/H2h6/H2h7/H2h8', substr($this->_data_recv, 0, 8));
-        $reply_id = hexdec($u['h8'] . $u['h7']);
+        // _data_recv can be shorter than 8 bytes (or empty) if a previous
+        // command/connect attempt failed or never received a reply; unpack()
+        // would otherwise emit "not enough input" warnings.
+        $reply_id = 0;
+        if (strlen($this->_data_recv) >= 8) {
+            $u = unpack('H2h1/H2h2/H2h3/H2h4/H2h5/H2h6/H2h7/H2h8', substr($this->_data_recv, 0, 8));
+            $reply_id = hexdec($u['h8'] . $u['h7']);
+        }
 
         $buf = Util::createHeader($command, $chksum, $session_id, $reply_id, $command_string);
 

--- a/tests/ShortDataGuardTest.php
+++ b/tests/ShortDataGuardTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use Jmrashed\Zkteco\Lib\Helper\Util;
+use Jmrashed\Zkteco\Lib\ZKTeco;
+
+class ShortDataGuardTest extends TestCase
+{
+    public function testCheckValidReturnsFalseInsteadOfWarningOnEmptyReply()
+    {
+        $this->assertFalse(Util::checkValid(''));
+        $this->assertFalse(Util::checkValid('abc'));
+    }
+
+    public function testGetSizeReturnsFalseInsteadOfWarningOnShortData()
+    {
+        $zk = $this->getMockBuilder(ZKTeco::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $zk->_data_recv = '';
+
+        $this->assertFalse(Util::getSize($zk));
+
+        $zk->_data_recv = 'ab';
+        $this->assertFalse(Util::getSize($zk));
+    }
+}


### PR DESCRIPTION
## Summary
- Reproduced the exact warning from the issue: \`unpack(): Type H: not enough input, need 1, have 0\`.
- Root cause: \`_command()\`, \`Util::getSize()\`, \`Util::checkValid()\`, and \`Connect::disconnect()\` all call \`unpack('H...', ...)\` on socket data without checking its length first. If a prior \`connect()\`/command attempt failed or timed out, leaving \`\$_data_recv\` short or empty, the next call emits this warning instead of failing gracefully — this matches the reported flow (\`connect()\` then \`getAttendance()\`, without checking \`connect()\`'s return value).
- Added length guards before each \`unpack()\` call so these fail closed (\`false\`/\`0\`) instead of warning, consistent with how these functions already signal failure elsewhere.

## Test plan
- [x] \`tests/ShortDataGuardTest.php\` — confirmed these tests actually emit the warning on the pre-fix code (verified via \`git stash\`) and pass cleanly after the fix.
- [x] Full suite — no new failures beyond pre-existing unrelated ones.

Fixes #2