### PR TITLE
Add opt-in sanity filtering to mitigate corrupted attendance records (#7, #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,19 @@ $rangeAttendance = $zk->getAttendanceByDateRange('2024-01-01', '2024-01-31 23:59
 ```
 Like the limit above, the device has no server-side time-range query, so this still downloads the full log and filters client-side — it's an ergonomics helper to avoid re-implementing the same date filtering loop in every project, not a way to speed up slow fetches from large logs.
 
+### 24.4a Sanitized Attendance Log (corrupted-record mitigation)
+
+Some devices (reported for the SpeedFace-V5L, see issues #7 / #12) return attendance records where only the first entry decodes correctly — later entries can contain `uid = 0`, non-printable badge ids, out-of-range state/type values, or garbage timestamps. This is a genuine record-format mismatch (the parsing in this library matches the iClock 680 layout, and some newer devices apparently use a different one) that needs a raw device packet capture to fix properly.
+
+As a best-effort mitigation, `getSanitizedAttendance()` filters out records that fail basic sanity checks:
+
+```php
+// Same as getAttendance(), but drops records that are clearly corrupted
+$attendanceLog = $zk->getSanitizedAttendance();
+```
+
+This is opt-in (not the default `getAttendance()` behavior) so it can't silently drop legitimate records on devices that already parse correctly. If you're affected by this and can share a raw packet capture, please comment on #7 or #12.
+
 ## 24.5 Clear Attendance Log
 ```php
 // Clear the attendance log from the ZKTeco device

--- a/src/Lib/Helper/Attendance.php
+++ b/src/Lib/Helper/Attendance.php
@@ -101,6 +101,63 @@ class Attendance
   }
 
   /**
+   * Fetch attendance data, discarding records that are clearly corrupted.
+   *
+   * Some devices (reported for SpeedFace-V5L, see issues #7 / #12) return
+   * attendance records where only the first entry decodes correctly and
+   * later entries contain obviously-invalid data (uid 0, non-printable
+   * badge ids, out-of-range state/type, sentinel/garbage timestamps). This
+   * is a real record-format mismatch that needs a raw device packet
+   * capture to fix properly (the parsing offsets here match the iClock 680
+   * format, which is a different/older record layout) - this method is a
+   * best-effort mitigation that filters out records failing basic sanity
+   * checks, not a fix for the underlying format difference. It's opt-in
+   * (not the default from get()) so it can't silently drop legitimate
+   * records for devices that already parse correctly.
+   *
+   * @param ZKTeco $self
+   * @return array
+   */
+  static public function getSanitized(ZKTeco $self)
+  {
+    $attendance = self::get($self);
+
+    return array_values(array_filter($attendance, [self::class, 'isPlausibleRecord']));
+  }
+
+  /**
+   * @param array $record
+   * @return bool
+   */
+  private static function isPlausibleRecord(array $record)
+  {
+    if (empty($record['uid'])) {
+      return false;
+    }
+
+    if (isset($record['id']) && $record['id'] !== '' && !ctype_print($record['id'])) {
+      return false;
+    }
+
+    if (isset($record['state']) && ($record['state'] < 0 || $record['state'] > 15)) {
+      return false;
+    }
+
+    if (isset($record['type']) && ($record['type'] < 0 || $record['type'] > 15)) {
+      return false;
+    }
+
+    if (isset($record['timestamp'])) {
+      $ts = strtotime($record['timestamp']);
+      if ($ts === false || $ts < strtotime('2000-01-02') || $ts > strtotime('+2 years')) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
    * Fetch attendance data and merge with user details.
    *
    * @param ZKTeco $self

--- a/src/Lib/ZKTeco.php
+++ b/src/Lib/ZKTeco.php
@@ -521,6 +521,20 @@ class ZKTeco
         return Attendance::getByDateRange($this, $start, $end);
     }
 
+/**
+ * Fetch attendance records, discarding ones that fail basic sanity checks
+ * (uid 0, non-printable badge id, out-of-range state/type, implausible
+ * timestamp). Mitigates corrupted entries reported on some devices
+ * (see #7 / #12) - it does not fix the underlying record-format mismatch,
+ * which needs a raw device packet capture to resolve properly.
+ *
+ * @return array
+ */
+    public function getSanitizedAttendance()
+    {
+        return Attendance::getSanitized($this);
+    }
+
     public function getTodaysRecords()
     {
         // Get all attendance records from the device

--- a/tests/AttendanceSanitizedTest.php
+++ b/tests/AttendanceSanitizedTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class AttendanceSanitizedTest extends TestCase
+{
+    /**
+     * Attendance::getSanitized() talks to a real device socket via get(),
+     * so exercise the isPlausibleRecord() filter directly against the exact
+     * corrupted SpeedFace-V5L output reported in issue #7, since that's the
+     * data this filter needs to reject.
+     */
+    private function isPlausibleRecord(array $record): bool
+    {
+        $reflection = new \ReflectionClass(\Jmrashed\Zkteco\Lib\Helper\Attendance::class);
+        $method = $reflection->getMethod('isPlausibleRecord');
+
+        return $method->invoke(null, $record);
+    }
+
+    public function testKeepsTheCorrectlyParsedRecord()
+    {
+        $record = ['uid' => 54, 'id' => 'NB2401010', 'state' => 4, 'timestamp' => '2024-11-28 16:43:25', 'type' => 1];
+
+        $this->assertTrue($this->isPlausibleRecord($record));
+    }
+
+    public function testRejectsZeroUidRecord()
+    {
+        $record = ['uid' => 0, 'id' => "\xff2", 'state' => 48, 'timestamp' => '2000-01-01 03:29:54', 'type' => 0];
+
+        $this->assertFalse($this->isPlausibleRecord($record));
+    }
+
+    public function testRejectsNonPrintableBadgeId()
+    {
+        $record = ['uid' => 1, 'id' => "\x04\xbd\x84\xb7/", 'state' => 0, 'timestamp' => '2035-02-10 22:20:41', 'type' => 49];
+
+        $this->assertFalse($this->isPlausibleRecord($record));
+    }
+
+    public function testRejectsOutOfRangeStateOrType()
+    {
+        $record = ['uid' => 1, 'id' => '557', 'state' => 0, 'timestamp' => '2024-01-01 08:00:00', 'type' => 49];
+
+        $this->assertFalse($this->isPlausibleRecord($record));
+    }
+
+    public function testRejectsEpochSentinelTimestamp()
+    {
+        $record = ['uid' => 13055, 'id' => '557', 'state' => 0, 'timestamp' => '2000-01-01 00:00:00', 'type' => 0];
+
+        $this->assertFalse($this->isPlausibleRecord($record));
+    }
+}


### PR DESCRIPTION
## Summary
- Issues #7 and #12 report that on some devices (SpeedFace-V5L), only the first attendance record decodes correctly — later records show `uid = 0`, non-printable badge ids, out-of-range state/type, or garbage timestamps.
- I compared the sample data in both issues against `Attendance::get()`'s parsing offsets, which match the iClock 680 record layout the issue confirms works. The corruption pattern (only entry 0 correct, everything after garbled) is consistent with the device actually using a different record size/layout that this library doesn't know about — but confirming the exact correct offsets requires a raw packet capture from the device, which I don't have access to. I'm not comfortable guessing new byte offsets and shipping them as a "fix" without being able to verify them.
- What I *can* verify: a sanity filter that rejects records matching the exact corruption signature from the issue (uid 0, non-printable id, out-of-range state/type, implausible/sentinel timestamp). Added `getSanitizedAttendance()` as an opt-in method (not the `getAttendance()` default) so it can't silently drop legitimate records for devices that already parse correctly.

**This does not close #7 or #12** — it's a mitigation, not the underlying fix. I'll leave both issues open and ask the reporters for a raw packet capture so the actual record layout can be corrected.

## Test plan
- [x] `tests/AttendanceSanitizedTest.php` — tests the filter directly against the exact corrupted values reported in issue #7 (uid 0 + binary id, non-printable id + out-of-range type, out-of-range type alone, and the epoch-sentinel timestamp), plus the correctly-parsed first record to confirm it isn't over-eager.
- [x] Full suite — no new failures beyond pre-existing unrelated ones.