### PR TITLE
fix(ci): drop unused orchestra/testbench blocking PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0",
-        "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
         "phpstan/phpstan": "^1.12 || ^2.0",
         "friendsofphp/php-cs-fixer": "^3.0"
     },


### PR DESCRIPTION
## Summary
The just-merged CI matrix (PR #26) fails on PHP 8.1:

\`\`\`
- orchestra/testbench[v9.0.0, ..., v9.17.0, v10.0.0, ..., v10.11.0] require php ^8.2
- orchestra/testbench[v11.0.0, ..., v11.1.0] require php ^8.3
\`\`\`

Every version of \`orchestra/testbench\` in the allowed range requires PHP >=8.2, so composer can't resolve anything on 8.1 at all. Checked, and \`orchestra/testbench\` isn't actually used anywhere — there's no \`Orchestra\Testbench\TestCase\` in \`tests/\`, only plain \`PHPUnit\Framework\TestCase\`. It was dead weight in \`require-dev\` that happened to impose a PHP floor higher than the package (which declares \`php: ^8.1\`) actually needs.

Removed it. \`phpunit/phpunit\`, \`phpstan/phpstan\`, and \`friendsofphp/php-cs-fixer\` all support PHP 8.1 through 8.5 on their own.

## Test plan
- [x] \`composer update\` resolves cleanly (verified on PHP 8.5 locally; the testbench-caused floor was the only PHP-8.1-incompatible dependency, confirmed via packagist metadata for all testbench 9.x/10.x/11.x releases).
- [x] Full test suite still passes at the same baseline.
- [ ] CI matrix (this PR) should go green on all 5 PHP versions once merged.